### PR TITLE
Improve Redirect Handling

### DIFF
--- a/assets/styles/index.ts
+++ b/assets/styles/index.ts
@@ -17,6 +17,7 @@ export const LIKE_ACTIONS = "#B644B2";
 export const DISLIKE_ACTIONS = "#363636";
 export const FLASH_ACTIONS = "#5028D7";
 
+export const ERROR = "#770707";
 
 export const DIMENSION_WIDTH = Dimensions.get("window").width;
 export const DIMENSION_HEIGHT = Dimensions.get("window").height;
@@ -495,7 +496,7 @@ export default StyleSheet.create({
     zIndex: 1,
     height: 100,
     position: "absolute",
-    backgroundColor: '#770707',
+    backgroundColor: ERROR,
     borderBottomWidth: 1,
     borderColor: 'red',
     width: '100%'

--- a/components/card-components/CardItem.tsx
+++ b/components/card-components/CardItem.tsx
@@ -10,6 +10,7 @@ import styles, {
   DIMENSION_HEIGHT,
   DIMENSION_WIDTH,
   DISLIKE_ACTIONS,
+  ERROR,
   FLASH_ACTIONS,
   SPOTIFY_GREEN,
   WHITE,
@@ -113,7 +114,7 @@ function CardItem({
           <TouchableOpacity style={styles.miniButton}>
             <Icon
               name="close"
-              color={FLASH_ACTIONS}
+              color={ERROR}
               size={20}
               onPress={() => {
                 swiper?.swipeLeft();
@@ -195,7 +196,7 @@ function CardItem({
           <TouchableOpacity style={styles.miniButton}>
             <Icon
               name="checkmark"
-              color={FLASH_ACTIONS}
+              color={SPOTIFY_GREEN}
               size={20}
               onPress={() => {
                 swiper?.swipeRight();

--- a/components/card-components/CardStackHandler.tsx
+++ b/components/card-components/CardStackHandler.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { View,  Platform } from 'react-native';
+import { View, Platform } from 'react-native';
 import Swiper from 'react-native-deck-swiper';
 import DATA from '../../assets/data/dummy_data_songs';
 import { DARK_GRAY } from '../../assets/styles';
@@ -218,5 +218,3 @@ function CardStackHandler(_style: any) {
 }
 
 export default CardStackHandler;
-
-

--- a/hooks/utils/auth-utils.ts
+++ b/hooks/utils/auth-utils.ts
@@ -2,9 +2,13 @@ import { Platform } from 'react-native';
 import { REDIRECT_URI, REDIRECT_URI_WEB } from '@env';
 
 // TODO: can maybe be replaced with: getRedirectUrl from expo auth session
-const redirectUri = Platform.OS === 'web' ? REDIRECT_URI_WEB : REDIRECT_URI;
-console.log(REDIRECT_URI, REDIRECT_URI_WEB);
+const redirectUriWeb = ['http://localhost:19006/', 'https://ollisco.github.io/swiperr/'].includes(window.location.href)
+  ? window.location.href : REDIRECT_URI_WEB;
+const redirectUri = Platform.OS === 'web' ? redirectUriWeb : REDIRECT_URI;
 
+
+
+console.log(redirectUri, window.location.href);
 // TODO: add all endpoints to here instead of useSpotifyAuth
 const authorizationEndpoint = 'https://accounts.spotify.com/authorize';
 const tokenEndpoint = 'https://accounts.spotify.com/api/token';


### PR DESCRIPTION
Since the redirect uri is the same as the window.location.href just base it on it. Thus we do not have to change the .env while deploying. (Currently deploying manually)